### PR TITLE
Correct link to overhead section in guidelines

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -98,7 +98,7 @@ OTF places high priority on funding tools that are open-source and freely availa
 {% hint style="info" %}
 ### Does OTF support overhead costs?
 
-OTF generally does not support standalone costs which are not directly associated with the completion of contractually stated objectives or deliverables. In the very limited instances where OTF determines that an overhead cost is permissible, such costs cannot be greater than 10% of the overall project cost. More information can be found [here under the "Overhead" section](https://www.opentech.fund/about/applying).
+OTF generally does not support standalone costs which are not directly associated with the completion of contractually stated objectives or deliverables. In the very limited instances where OTF determines that an overhead cost is permissible, such costs cannot be greater than 10% of the overall project cost. More information can be found [here under the "Overhead Costs" section](../general-funding-guidelines.md#overhead-costs).
 {% endhint %}
 
 {% hint style="info" %}


### PR DESCRIPTION
www.opentech.fund/about/applying redirects to guide.opentech.fund, this changes the link to an internal section about it in `general-funding-guidelines.md`